### PR TITLE
bump restate sdk to 0.4.1

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,5 @@
 hypercorn
-restate-sdk==0.4.0
+restate-sdk==0.4.1
 pydantic==2.8.2
 anthropic==0.36.0
 shortuuid==1.0.13


### PR DESCRIPTION
This PR bumps the python-sdk version to `0.4.1` , with that :crossed_fingers: it should be possible to use Pydantic directly via type hints.

I've checked this locally on this project:


```bash
curl localhost:8080/cyoa/a/generate_story --json '{ "story_id" : "a", "user_id" : "b", "title" : "hi", "content" : "a story", "main_character" : "bob" }'
```

Results in an expected log message.